### PR TITLE
PEP518 build spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Allows package to specify its own build dependencies so cython doesn't need to be pre-installed.