### PR TITLE
add build requirements to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "Cython"]


### PR DESCRIPTION
Solve `cython` build dependencies issue as noted in #10