### PR TITLE
(-> restructure branch) Fix AddLocalShapeDescriptor usage and requirement URLs in tutorial code

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This repository contains code to compute Local Shape Descriptors (LSDs) from an 
  matplotlib
  scikit-image
 
- repos (i.e pip install git+git://github.com/{repo})
+ repos (i.e pip install git+https://github.com/{repo})
  
  funkelab/funlib.segment.git
  funkelab/lsd.git

--- a/lsd/tutorial/example_nets/fib25/lsd/train.py
+++ b/lsd/tutorial/example_nets/fib25/lsd/train.py
@@ -135,7 +135,7 @@ def train_until(max_iteration):
         AddLocalShapeDescriptor(
             labels,
             gt_embedding,
-            mask=gt_embedding_scale,
+            lsds_mask=gt_embedding_scale,
             sigma=80,
             downsample=2) +
         UnmaskBackground(gt_embedding_scale, labels_mask) +

--- a/lsd/tutorial/example_nets/fib25/mtlsd/train.py
+++ b/lsd/tutorial/example_nets/fib25/mtlsd/train.py
@@ -144,7 +144,7 @@ def train_until(max_iteration):
         AddLocalShapeDescriptor(
             labels,
             gt_lsds,
-            mask=gt_lsds_scale,
+            lsds_mask=gt_lsds_scale,
             sigma=80,
             downsample=2) +
         UnmaskBackground(gt_lsds_scale, labels_mask) +

--- a/lsd/tutorial/notebooks/basic_gp_tutorial.ipynb
+++ b/lsd/tutorial/notebooks/basic_gp_tutorial.ipynb
@@ -56,8 +56,8 @@
         "!pip install zarr \n",
         "\n",
         "# repos\n",
-        "!pip install git+git://github.com/funkey/gunpowder.git\n",
-        "!pip install git+git://github.com/funkelab/funlib.learn.torch.git"
+        "!pip install git+https://github.com/funkey/gunpowder.git\n",
+        "!pip install git+https://github.com/funkelab/funlib.learn.torch.git"
       ],
       "execution_count": null,
       "outputs": []

--- a/lsd/tutorial/notebooks/inference.ipynb
+++ b/lsd/tutorial/notebooks/inference.ipynb
@@ -49,9 +49,9 @@
         "!pip install zarr\n",
         "\n",
         "# repos\n",
-        "!pip install git+git://github.com/funkey/gunpowder.git\n",
-        "!pip install git+git://github.com/funkelab/funlib.learn.torch.git\n",
-        "!pip install git+git://github.com/funkey/waterz.git"
+        "!pip install git+https://github.com/funkey/gunpowder.git\n",
+        "!pip install git+https://github.com/funkelab/funlib.learn.torch.git\n",
+        "!pip install git+https://github.com/funkey/waterz.git"
       ],
       "execution_count": null,
       "outputs": []

--- a/lsd/tutorial/notebooks/segment.ipynb
+++ b/lsd/tutorial/notebooks/segment.ipynb
@@ -51,10 +51,10 @@
         "!pip install zarr\n",
         "\n",
         "# repos\n",
-        "!pip install git+git://github.com/funkelab/daisy.git\n",
-        "!pip install git+git://github.com/funkey/gunpowder.git\n",
-        "!pip install git+git://github.com/funkelab/funlib.learn.torch.git\n",
-        "!pip install git+git://github.com/funkey/waterz.git"
+        "!pip install git+https://github.com/funkelab/daisy.git\n",
+        "!pip install git+https://github.com/funkey/gunpowder.git\n",
+        "!pip install git+https://github.com/funkelab/funlib.learn.torch.git\n",
+        "!pip install git+https://github.com/funkey/waterz.git"
       ],
       "execution_count": null,
       "outputs": []

--- a/lsd/tutorial/notebooks/train_affinities.ipynb
+++ b/lsd/tutorial/notebooks/train_affinities.ipynb
@@ -52,8 +52,8 @@
         "!pip install zarr \n",
         "\n",
         "# repos\n",
-        "!pip install git+git://github.com/funkey/gunpowder.git\n",
-        "!pip install git+git://github.com/funkelab/funlib.learn.torch.git"
+        "!pip install git+https://github.com/funkey/gunpowder.git\n",
+        "!pip install git+https://github.com/funkelab/funlib.learn.torch.git"
       ],
       "execution_count": null,
       "outputs": []

--- a/lsd/tutorial/notebooks/train_lsds.ipynb
+++ b/lsd/tutorial/notebooks/train_lsds.ipynb
@@ -51,12 +51,12 @@
         "!pip install zarr\n",
         "\n",
         "# repos\n",
-        "!pip install git+git://github.com/funkelab/daisy.git\n",
-        "!pip install git+git://github.com/funkey/gunpowder.git\n",
-        "!pip install git+git://github.com/funkelab/funlib.learn.torch.git\n",
-        "!pip install git+git://github.com/funkelab/funlib.segment.git\n",
-        "!pip install git+git://github.com/funkelab/lsd.git\n",
-        "!pip install git+git://github.com/funkey/waterz.git"
+        "!pip install git+https://github.com/funkelab/daisy.git\n",
+        "!pip install git+https://github.com/funkey/gunpowder.git\n",
+        "!pip install git+https://github.com/funkelab/funlib.learn.torch.git\n",
+        "!pip install git+https://github.com/funkelab/funlib.segment.git\n",
+        "!pip install git+https://github.com/funkelab/lsd.git\n",
+        "!pip install git+https://github.com/funkey/waterz.git"
       ],
       "execution_count": null,
       "outputs": []

--- a/lsd/tutorial/notebooks/train_lsds.ipynb
+++ b/lsd/tutorial/notebooks/train_lsds.ipynb
@@ -431,7 +431,7 @@
         "    pipeline += AddLocalShapeDescriptor(\n",
         "        labels,\n",
         "        gt_lsds,\n",
-        "        mask=lsds_weights,\n",
+        "        lsds_mask=lsds_weights,\n",
         "        sigma=80,\n",
         "        downsample=1)\n",
         "\n",

--- a/lsd/tutorial/notebooks/train_mtlsd.ipynb
+++ b/lsd/tutorial/notebooks/train_mtlsd.ipynb
@@ -460,7 +460,7 @@
         "    pipeline += AddLocalShapeDescriptor(\n",
         "        labels,\n",
         "        gt_lsds,\n",
-        "        mask=lsds_weights,\n",
+        "        lsds_mask=lsds_weights,\n",
         "        sigma=80,\n",
         "        downsample=1)\n",
         "        \n",

--- a/lsd/tutorial/notebooks/train_mtlsd.ipynb
+++ b/lsd/tutorial/notebooks/train_mtlsd.ipynb
@@ -51,12 +51,12 @@
         "!pip install zarr\n",
         "\n",
         "# repos\n",
-        "!pip install git+git://github.com/funkelab/daisy.git\n",
-        "!pip install git+git://github.com/funkey/gunpowder.git\n",
-        "!pip install git+git://github.com/funkelab/funlib.learn.torch.git\n",
-        "!pip install git+git://github.com/funkelab/funlib.segment.git\n",
-        "!pip install git+git://github.com/funkelab/lsd.git\n",
-        "!pip install git+git://github.com/funkey/waterz.git"
+        "!pip install git+https://github.com/funkelab/daisy.git\n",
+        "!pip install git+https://github.com/funkey/gunpowder.git\n",
+        "!pip install git+https://github.com/funkelab/funlib.learn.torch.git\n",
+        "!pip install git+https://github.com/funkelab/funlib.segment.git\n",
+        "!pip install git+https://github.com/funkelab/lsd.git\n",
+        "!pip install git+https://github.com/funkey/waterz.git"
       ],
       "execution_count": null,
       "outputs": []

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ h5py
 scikit-image
 requests
 cython
-git+git://github.com/funkey/waterz@8ccd0b308fed604d143577f128420da83ff444da#egg=waterz
-git+git://github.com/funkey/gunpowder@28fbe7914e235edc1eb15bfdf695da15ac48bb32#egg=gunpowder
-git+git://github.com/funkelab/funlib.segment@09246e7aed32210747800906846d03788ca10b81#egg=funlib.segment
+git+https://github.com/funkey/waterz@8ccd0b308fed604d143577f128420da83ff444da#egg=waterz
+git+https://github.com/funkey/gunpowder@28fbe7914e235edc1eb15bfdf695da15ac48bb32#egg=gunpowder
+git+https://github.com/funkelab/funlib.segment@09246e7aed32210747800906846d03788ca10b81#egg=funlib.segment


### PR DESCRIPTION
This is the same as PR #13 but for the `restructure` branch.

Closes #13.