### PR TITLE
Publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,34 @@
+name: Publish
+
+on:
+  push:
+    tags: "*"
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Install pypa/build
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+      - name: Publish distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install .
+        pip install -r requirements-dev.txt
+    - name: Test with pytest
+      run: |
+        pytest tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+matplotlib
+zarr
+luigi
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,2 @@
-mahotas
-numpy
-scipy
-h5py
-scikit-image
-requests
-cython
-git+git://github.com/funkey/waterz@8ccd0b308fed604d143577f128420da83ff444da#egg=waterz
-git+git://github.com/funkey/gunpowder@28fbe7914e235edc1eb15bfdf695da15ac48bb32#egg=gunpowder
-git+git://github.com/funkelab/funlib.segment@09246e7aed32210747800906846d03788ca10b81#egg=funlib.segment
+git+https://github.com/funkey/waterz@8ccd0b308fed604d143577f128420da83ff444da#egg=waterz
+git+https://github.com/funkelab/funlib.segment@09246e7aed32210747800906846d03788ca10b81#egg=funlib.segment

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.extension import Extension
 from setuptools import find_packages
 
 setup(
-        name='lsd',
+        name='lsds',
         version='0.1',
         description='Local Shape Descriptors.',
         url='https://github.com/funkey/lsd',
@@ -21,5 +21,15 @@ setup(
                 extra_compile_args=['-O3'],
                 language='c++')
         ],
-        cmdclass={'build_ext': build_ext}
+        cmdclass={'build_ext': build_ext},
+        install_requires=[
+            "mahotas",
+            "numpy",
+            "scipy",
+            "h5py",
+            "scikit-image",
+            "requests",
+            "cython",
+            "gunpowder",
+        ]
 )


### PR DESCRIPTION
Added a couple github actions.
1) publish. If you click on release on the main github page, create a release and create a new tag for that release, everything else will be handled automatically. You do need to add a PYPI_API_TOKEN secret to the repository which you can get from pypi.
2) tests. I tried to run the tests, I ran into quite a few errors, mainly luigi interface errors when trying to run and boost compilation errors when trying to install waterz and funlib.segment.

All pip installable packages are now in the setup.py and will be installed automatically on pip install.
Last remaining dependencies are waterz and funlib.segment, both of which are more annoying due to the boost dependency, but those are only needed for the  post processing functions so probably still worth publishing